### PR TITLE
Show actual dice rolls for consumables

### DIFF
--- a/lang/cs.json
+++ b/lang/cs.json
@@ -155,8 +155,6 @@
   "PUSHED": "Zkoušení štěstí",
   "DAMAGE": "Zranění",
   "POWER_LEVEL": "Síla kouzla",
-  "SUCCEED": "Úspěch",
-  "FAILED": "Neúspěch",
 
   "MONSTER.NAME": "Název",
   "MONSTER.DICE": "Kostka",

--- a/lang/de.json
+++ b/lang/de.json
@@ -156,8 +156,6 @@
   "DAMAGE": "Schaden",
   "ENCUMBRANCE": "Überlast",
   "POWER_LEVEL": "Machtstufe",
-  "SUCCEED": "Erfolg",
-  "FAILED": "Fehlschlag",
 
   "MONSTER.NAME": "Name",
   "MONSTER.DICE": "Würfel",

--- a/lang/en.json
+++ b/lang/en.json
@@ -168,8 +168,6 @@
   "DAMAGE": "Damage",
   "ENCUMBRANCE": "Encumbrance",
   "POWER_LEVEL": "Power Level",
-  "SUCCEED": "Succeed",
-  "FAILED": "Failed",
   "OTHER": "OTHER",
   "CARRYING_CAPACITY": "Carrying capacity",
 

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -168,8 +168,6 @@
   "DAMAGE": "Dégât",
   "ENCUMBRANCE": "Encombrement",
   "POWER_LEVEL": "Puissance",
-  "SUCCEED": "Succès",
-  "FAILED": "Echec",
   "OTHER": "AUTRE",
   "CARRYING_CAPACITY": "Capacité de transport",
 

--- a/lang/pt-br.json
+++ b/lang/pt-br.json
@@ -155,8 +155,6 @@
   "PUSHED": "Forçou",
   "DAMAGE": "Dano",
   "POWER_LEVEL": "Nível de Poder",
-  "SUCCEED": "Passou",
-  "FAILED": "Falhou",
 
   "MONSTER.NAME": "Nome",
   "MONSTER.DICE": "Dados",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -168,8 +168,6 @@
   "DAMAGE": "Skada",
   "ENCUMBRANCE": "Belastning",
   "POWER_LEVEL": "Effektgrad",
-  "SUCCEED": "Lyckat",
-  "FAILED": "Misslyckat",
   "CARRYING_CAPACITY": "Bärförmåga",
   "OTHER": "ÖVRIGA",
 

--- a/model/tab/gear.html
+++ b/model/tab/gear.html
@@ -145,6 +145,9 @@
         </div>
     </div>
     <div class="consumables border">
+        <div class="consumable">
+            <i class="fas fa-dice"></i>
+        </div>
         {{#each actor.data.consumable as |consumable key|}}
         <div class="consumable">
             <button type="button" class="roll-consumable" data-consumable="{{key}}">{{localize consumable.label}}</button>

--- a/script/components/dice-roller.js
+++ b/script/components/dice-roller.js
@@ -65,41 +65,6 @@ export default class DiceRoller {
     }
   }
 
-  /**
-   * @param  {object} consumable {label: consumable name, value: number of die faces}
-   */
-  async rollConsumable(consumable) {
-    let consumableName = game.i18n.localize(consumable.label);
-    let result;
-    if (!consumable.value) {
-      result = "FAILED";
-    } else {
-      let die = new Die({ faces: consumable.value, number: 1 });
-      die.evaluate();
-      if (die.total > 2) {
-        result = "SUCCEED";
-      } else {
-        result = "FAILED";
-      }
-    }
-    let consumableData = {
-      name: consumableName,
-      result: game.i18n.localize(result),
-    };
-    const html = await renderTemplate("systems/forbidden-lands/chat/consumable.html", consumableData);
-    let chatData = {
-      user: game.user._id,
-      rollMode: game.settings.get("core", "rollMode"),
-      content: html,
-    };
-    if (["gmroll", "blindroll"].includes(chatData.rollMode)) {
-      chatData.whisper = ChatMessage.getWhisperRecipients("GM");
-    } else if (chatData.rollMode === "selfroll") {
-      chatData.whisper = [game.user];
-    }
-    ChatMessage.create(chatData);
-  }
-
   synthetizeFakeRoll(dice) {
     const terms = [];
     for (let die of dice) {

--- a/script/sheet/character.js
+++ b/script/sheet/character.js
@@ -86,9 +86,13 @@ export class ForbiddenLandsCharacterSheet extends ForbiddenLandsActorSheet {
       RollDialog.prepareRollDialog("HEADER.ARMOR", 0, 0, armorTotal, "", 0, 0, this.diceRoller);
     });
     html.find(".roll-consumable").click((ev) => {
-      const consumableName = $(ev.currentTarget).data("consumable");
-      const consumable = this.actor.data.data.consumable[consumableName];
-      this.diceRoller.rollConsumable(consumable);
+      const consumable = this.actor.data.data.consumable[$(ev.currentTarget).data("consumable")];
+      const consumableName = game.i18n.localize(consumable.label);
+      if (consumable.value == 6) {
+        this.diceRoller.roll(consumableName, 0, 1, 0, [], 0);
+      } else if (consumable.value > 6) {
+        this.diceRoller.roll(consumableName, 0, 0, 0, [{"dice": 1, "face": consumable.value}], 0);
+      }
     });
     html.find(".currency-button").on("click contextmenu", (ev) => {
       const currency = $(ev.currentTarget).data("currency");

--- a/style/tab/gear.css
+++ b/style/tab/gear.css
@@ -31,15 +31,16 @@
 
 .forbidden-lands .character .consumables {
   display: grid;
-  gap: 8px;
-  grid-template-columns: auto auto auto auto;
+  grid-template-columns: auto auto auto auto auto;
 }
 
 .forbidden-lands .character .consumables .consumable {
+  display: flex;
+  flex-direction: row;
   align-items: center;
   font-family: var(--font-special);
   padding: 8px 0;
-  text-align: center;
+  justify-content: center;
 }
 
 .forbidden-lands .character .consumables .consumable select {


### PR DESCRIPTION
Here is a preferential change that not everyone might agree with. I'm
putting it up here to see what people think.

This commit removes the `rollConsumable` method from the `DiceRoller`
class. The consumable roll is then replaced with a straight up call to
the normal `roll` method instead. This means the automatic "Succeed" or
"Failed" message is no longer shown and the players need to interpret
the die result themselves. The reasoning for this change is increased
transparency of what was actually rolled. (In my experience the simple
result of success or failure was often treated with suspicion from my
players.)

This commit also adds a dice icon to the consumable bar as an attempted
clue to the fact that the labels are infact clickable to make the
associated roll -- something that is otherwise far from obvious.