### PR TITLE
Case insensitive artifacts

### DIFF
--- a/script/dialog/roll-dialog.js
+++ b/script/dialog/roll-dialog.js
@@ -144,7 +144,7 @@ export class RollDialog {
      * @param  {string} artifact
      */
     static parseArtifact(artifact) {
-        let regex = /([0-9]*)d([0-9]*)/g;
+        let regex = /([0-9]*)d([0-9]*)/gi;
         let regexMatch;
         let artifacts = [];
         while (regexMatch = regex.exec(artifact)) {

--- a/script/sheet/actor.js
+++ b/script/sheet/actor.js
@@ -183,7 +183,7 @@ export class ForbiddenLandsActorSheet extends ActorSheet {
   }
 
   isArtifact(artifact) {
-    let regex = /([0-9]*)d([0-9]*)/;
+    let regex = /([0-9]*)d([0-9]*)/i;
     return !!regex.exec(artifact);
   }
 


### PR DESCRIPTION
This commit allows us to use uppercase D as well as lowercase d when
referring to the artifact dice d8, d10 and d12.