### PR TITLE
Special Encumbrance Values

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -255,5 +255,7 @@
   "WEIGHT.LIGHT": "Light",
   "WEIGHT.NONE": "None",
   "WEIGHT.REGULAR": "Normal",
-  "WEIGHT.TINY": "Tiny"
+  "WEIGHT.TINY": "Tiny",
+  "WEIGHT.TYPE_REGULAR": "Regular",
+  "WEIGHT.TYPE_SPECIAL": "Special"
 }

--- a/model/tab/gear/gear-main.html
+++ b/model/tab/gear/gear-main.html
@@ -3,17 +3,21 @@
         <label>{{localize "GEAR.WEIGHT"}}</label>
         <select name="data.weight">
             {{#select data.weight}}
-                <option value="none">{{localize "WEIGHT.NONE"}}</option>
-                <option value="tiny">{{localize "WEIGHT.TINY"}}</option>
-                <option value="light">{{localize "WEIGHT.LIGHT"}}</option>
-                <option value="regular">{{localize "WEIGHT.REGULAR"}}</option>
-                <option value="heavy">{{localize "WEIGHT.HEAVY"}}</option>
-                <option value="3">3</option>
-                <option value="4">4</option>
-                <option value="5">5</option>
-                <option value="6">6</option>
-                <option value="7">7</option>
-                <option value="8">8</option>
+                <optgroup label={{localize "WEIGHT.TYPE_REGULAR" }}>
+                    <option value="none">{{localize "WEIGHT.NONE"}}</option>
+                    <option value="tiny">{{localize "WEIGHT.TINY"}}</option>
+                    <option value="light">{{localize "WEIGHT.LIGHT"}}</option>
+                    <option value="regular">{{localize "WEIGHT.REGULAR"}}</option>
+                    <option value="heavy">{{localize "WEIGHT.HEAVY"}}</option>
+                </optgroup>
+                <optgroup label={{localize "WEIGHT.TYPE_SPECIAL" }}>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                    <option value="5">5</option>
+                    <option value="6">6</option>
+                    <option value="7">7</option>
+                    <option value="8">8</option>
+                </optgroup>
             {{/select}}
         </select>
     </div>

--- a/model/tab/gear/gear-main.html
+++ b/model/tab/gear/gear-main.html
@@ -8,6 +8,12 @@
                 <option value="light">{{localize "WEIGHT.LIGHT"}}</option>
                 <option value="regular">{{localize "WEIGHT.REGULAR"}}</option>
                 <option value="heavy">{{localize "WEIGHT.HEAVY"}}</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="7">7</option>
+                <option value="8">8</option>
             {{/select}}
         </select>
     </div>
@@ -15,5 +21,5 @@
             name="data.effect">{{data.effect}}</textarea></div>
 </div>
 <div class="roll-modifiers border">
-{{> systems/forbidden-lands/model/partial/roll-modifiers.html }}
+    {{> systems/forbidden-lands/model/partial/roll-modifiers.html }}
 </div>

--- a/script/hooks/handlebars.js
+++ b/script/hooks/handlebars.js
@@ -82,6 +82,8 @@ function registerHandlebarsHelpers() {
         return game.i18n.localize("WEIGHT.REGULAR");
       case "heavy":
         return game.i18n.localize("WEIGHT.HEAVY");
+      default:
+        return weight;
     }
   });
   Handlebars.registerHelper("weaponCategory", function (category) {

--- a/script/sheet/character.js
+++ b/script/sheet/character.js
@@ -155,6 +155,18 @@ export class ForbiddenLandsCharacterSheet extends ForbiddenLandsActorSheet {
             return 0.5;
           case "heavy":
             return 2;
+          case "3":
+            return 3;
+          case "4":
+            return 4;
+          case "5":
+            return 5;
+          case "6":
+            return 6;
+          case "7":
+            return 7;
+          case "8":
+            return 8;
           default:
             return 1;
         }


### PR DESCRIPTION
This feature update brings special encumbrance values to the "Gear" category. This is to accomodate valuable finds that weigh more than Heavy, as well as animals and other objects that could conceivably be carried. 

Only Gear features the special encumbrance values as the Forbidden Lands, so far, has not indicated that any other category has the need for it.
![2021-02-25](https://user-images.githubusercontent.com/9851733/109229594-d624dc00-77c3-11eb-82ca-0659d8af56ac.png)
