### PR TITLE
Improve posting items to chat

### DIFF
--- a/chat/item.html
+++ b/chat/item.html
@@ -2,7 +2,6 @@
     <div class="border">
         <div class="link-header">
             <h3>{{name}}</h3>
-            {{link}}
         </div>
         {{#if isArmor}}
             <h4>{{armorPart data.part}}</h4>

--- a/script/actor/forbidden-lands.js
+++ b/script/actor/forbidden-lands.js
@@ -20,7 +20,6 @@ export class ForbiddenLandsItem extends Item {
     if (itemData.img.includes("/mystery-man")) {
       itemData.img = null;
     }
-    itemData.link = this.link;
     itemData.isArmor = itemData.type === "armor";
     itemData.isBuilding = itemData.type === "building";
     itemData.isCriticalInjury = itemData.type === "criticalInjury";
@@ -38,6 +37,7 @@ export class ForbiddenLandsItem extends Item {
       user: game.user._id,
       rollMode: game.settings.get("core", "rollMode"),
       content: html,
+      ["flags.forbidden-lands.itemData"] : this.data // Adds posted item data to chat message flags for item drag/drop
     };
     if (["gmroll", "blindroll"].includes(chatData.rollMode)) {
       chatData.whisper = ChatMessage.getWhisperRecipients("GM");

--- a/script/init.js
+++ b/script/init.js
@@ -102,6 +102,7 @@ Hooks.on("renderChatMessage", async (app, html, msg) => {
   let postedItem = html.find(".chat-item")[0];
   if (postedItem)
   {
+    postedItem.classList.add("draggable")
     postedItem.setAttribute("draggable", true);
     postedItem.addEventListener('dragstart', ev => {
       ev.dataTransfer.setData("text/plain", JSON.stringify({item : app.getFlag("forbidden-lands", "itemData"), type : "itemDrop"}));

--- a/script/init.js
+++ b/script/init.js
@@ -95,3 +95,16 @@ Hooks.once("ready", () => {
 Hooks.once("diceSoNiceReady", (dice3d) => {
   registerDiceSoNice(dice3d);
 });
+
+Hooks.on("renderChatMessage", async (app, html, msg) => {
+
+  // Add drag and drop functonality to posted items
+  let postedItem = html.find(".chat-item")[0];
+  if (postedItem)
+  {
+    postedItem.setAttribute("draggable", true);
+    postedItem.addEventListener('dragstart', ev => {
+      ev.dataTransfer.setData("text/plain", JSON.stringify({item : app.getFlag("forbidden-lands", "itemData"), type : "itemDrop"}));
+    })
+  }
+})

--- a/script/sheet/actor.js
+++ b/script/sheet/actor.js
@@ -4,6 +4,10 @@ import DiceRoller from "../components/dice-roller.js";
 export class ForbiddenLandsActorSheet extends ActorSheet {
   diceRoller = new DiceRoller();
 
+  /**
+   * @override
+   * Extends the sheet drop handler for system specific usages
+   */
   async _onDrop(event) 
   {
     let dragData = JSON.parse(event.dataTransfer.getData("text/plain"));
@@ -11,8 +15,8 @@ export class ForbiddenLandsActorSheet extends ActorSheet {
     // To be extended if future features add more drop functionality
     if (dragData.type === "itemDrop")
       this.actor.createEmbeddedEntity("OwnedItem", dragData.item)
-    else 
-      super._onDrop(event)
+    else // Call base _onDrop for normal FVTT drop handling
+      super._onDrop(event) 
   }
 
 

--- a/script/sheet/actor.js
+++ b/script/sheet/actor.js
@@ -4,6 +4,18 @@ import DiceRoller from "../components/dice-roller.js";
 export class ForbiddenLandsActorSheet extends ActorSheet {
   diceRoller = new DiceRoller();
 
+  async _onDrop(event) 
+  {
+    let dragData = JSON.parse(event.dataTransfer.getData("text/plain"));
+
+    // To be extended if future features add more drop functionality
+    if (dragData.type === "itemDrop")
+      this.actor.createEmbeddedEntity("OwnedItem", dragData.item)
+    else 
+      super._onDrop(event)
+  }
+
+
   activateListeners(html) {
     super.activateListeners(html);
 

--- a/style/common.css
+++ b/style/common.css
@@ -305,19 +305,6 @@
 .forbidden-lands.chat-item .link-header {
   text-align: center;
 }
-.forbidden-lands.chat-item .link-header a {
-  display: none;
-  line-height: 16px;
-  margin: 0 0 4px;
-  white-space: unset;
-  word-break: unset;
-}
-.forbidden-lands.chat-item .link-header:hover a {
-  display: inline-block;
-}
-.forbidden-lands.chat-item .link-header:hover h3 {
-  display: none;
-}
 .forbidden-lands.chat-item strong {
   text-transform: uppercase;
 }


### PR DESCRIPTION
Removed the Entity link in posted item chat cards. Instead, item data is stored in chat message flags and transferred to the actor when the chat card is dragged onto their sheet.

This removes the need for the item to exist in the world for drag+drop to work.