### PR TITLE
Display all weapon features in character sheet

### DIFF
--- a/model/tab/combat.html
+++ b/model/tab/combat.html
@@ -20,7 +20,12 @@
                             </div>
                             <div class="name">
                                 <button type="button" class="roll-weapon" data-item-id="{{item._id}}">{{item.name}}</button>
-                                <span>{{weaponGrip item.data.grip}}{{#if item.data.features.others}}, {{/if}}{{item.data.features.others}}</span>
+                                <span>
+                                    {{weaponGrip item.data.grip}}
+                                    {{#if (hasWeaponFeatures item.data.category item.data.features)}}
+                                        , {{formatWeaponFeatures item.data.category item.data.features}}
+                                    {{/if}}
+                                </span>
                             </div>
                         </div>
                         <div class="damage">{{item.data.damage}}</div>


### PR DESCRIPTION
Fixes a small UI bug introduced with #47: only weapon's additional
("others") features would appear in the character sheet's combat tab.

This fix reverts back to the old behaviour as all weapon features should
appear for each eligible items.