### PR TITLE
feat: ✨ Item Quantities added to Stronghold Sheet.

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -162,6 +162,7 @@
 	"ITEM.DELETE_MODIFIER": "Delete modifier",
 	"ITEM.NO_MODIFIERS": "No modifiers",
 	"ITEM.ROLL_MODIFIERS": "Roll Modifiers",
+	"ITEM.QUANTITY": "Quantity",
 	"ITEM.TypeArmor": "Armor",
 	"ITEM.TypeBuilding": "Stronghold Building",
 	"ITEM.TypeCriticalinjury": "Critical Injury",

--- a/src/module/sheets/actor/actor.js
+++ b/src/module/sheets/actor/actor.js
@@ -191,6 +191,13 @@ export class ForbiddenLandsActorSheet extends ActorSheet {
 				null,
 			);
 		});
+		html.find(".quantity").on("blur", (ev) => {
+			const itemId = ev.currentTarget.parentElement.dataset.itemId;
+			this.actor.updateOwnedItem({
+				_id: itemId,
+				"data.quantity": ev.currentTarget.value,
+			});
+		});
 	}
 
 	parseModifiers(str) {
@@ -258,7 +265,7 @@ export class ForbiddenLandsActorSheet extends ActorSheet {
 		const config = game.fbl.config.encumbrance;
 		const type = data.type;
 		const weight = data.data?.weight;
-		if (data.type === "rawMaterial") return 1;
+		if (data.type === "rawMaterial") return 1 * Number(data.data.quantity);
 		if (type !== "gear" && type !== "armor" && type !== "weapon") return null;
 		return Number(config[weight] ?? 1) ?? Number(weight) ?? 1;
 	}

--- a/src/module/sheets/actor/stronghold.js
+++ b/src/module/sheets/actor/stronghold.js
@@ -21,7 +21,7 @@ export class ForbiddenLandsStrongholdSheet extends ForbiddenLandsActorSheet {
 
 	getData() {
 		const data = super.getData();
-		this.computeItems(data);
+		this._computeItems(data);
 		return data;
 	}
 
@@ -32,7 +32,7 @@ export class ForbiddenLandsStrongholdSheet extends ForbiddenLandsActorSheet {
 		});
 	}
 
-	computeItems(data) {
+	_computeItems(data) {
 		for (let item of Object.values(data.items)) {
 			item.isWeapon = item.type === "weapon";
 			item.isArmor = item.type === "armor";
@@ -40,6 +40,10 @@ export class ForbiddenLandsStrongholdSheet extends ForbiddenLandsActorSheet {
 			item.isRawMaterial = item.type === "rawMaterial";
 			item.isBuilding = item.type === "building";
 			item.isHireling = item.type === "hireling";
+			if (item.type !== "building" || item.type !== "hireling") {
+				item.totalWeight =
+					game.fbl.config.encumbrance[item.data.weight] ?? item.data.weight ?? 1 * item.data.quantity ?? 1;
+			}
 		}
 	}
 

--- a/src/module/sheets/actor/stronghold.js
+++ b/src/module/sheets/actor/stronghold.js
@@ -42,7 +42,8 @@ export class ForbiddenLandsStrongholdSheet extends ForbiddenLandsActorSheet {
 			item.isHireling = item.type === "hireling";
 			if (item.type !== "building" || item.type !== "hireling") {
 				item.totalWeight =
-					game.fbl.config.encumbrance[item.data.weight] ?? item.data.weight ?? 1 * item.data.quantity ?? 1;
+					(game.fbl.config.encumbrance[item.data.weight] ?? item.data.weight ?? 1) *
+					(item.data.quantity ?? 1);
 			}
 		}
 	}

--- a/src/module/system/config.js
+++ b/src/module/system/config.js
@@ -12,7 +12,7 @@ FBL.encumbrance = {
 	tiny: 0,
 	none: 0,
 	light: 0.5,
-	normal: 1,
+	regular: 1,
 	heavy: 2,
 };
 

--- a/src/styles/sheets/tab/_gear.scss
+++ b/src/styles/sheets/tab/_gear.scss
@@ -96,9 +96,16 @@
 	margin-left: 4px;
 }
 
-.forbidden-lands .character .gears .bonus {
+.forbidden-lands .character .gears .bonus,
+.forbidden-lands .character .gears .quantity {
 	flex-basis: 15%;
 	text-align: center;
+}
+
+.forbidden-lands .character .gears input.quantity {
+	flex-basis: 8%;
+	margin-right: 3%;
+	margin-left: 5%;
 }
 
 .forbidden-lands .character .gears .bonus.broken {

--- a/src/styles/sheets/tab/_monster-gear.scss
+++ b/src/styles/sheets/tab/_monster-gear.scss
@@ -29,9 +29,16 @@
 	margin-left: 4px;
 }
 
-.forbidden-lands .monster .gears .bonus {
+.forbidden-lands .monster .gears .bonus,
+.forbidden-lands .monster .gears .quantity {
 	flex-basis: 15%;
 	text-align: center;
+}
+
+.forbidden-lands .monster .gears input.quantity {
+	flex-basis: 8%;
+	margin-right: 3%;
+	margin-left: 5%;
 }
 
 .forbidden-lands .monster .gears .bonus.broken {

--- a/src/styles/sheets/tab/_stronghold-gear.scss
+++ b/src/styles/sheets/tab/_stronghold-gear.scss
@@ -1,50 +1,48 @@
 .forbidden-lands .stronghold .gears {
 	padding-bottom: 8px;
-}
 
-.forbidden-lands .stronghold .gears .items .header {
-	margin: 0;
-	width: 100%;
-}
+	.items .header {
+		margin: 0;
+		width: 100%;
+	}
 
-.forbidden-lands .stronghold .gears .items div + .header {
-	margin-top: 8px;
-}
+	.items div + .header {
+		margin-top: 8px;
+	}
 
-.forbidden-lands .stronghold .gears .gear {
-	align-items: center;
-}
+	.gear {
+		align-items: center;
+	}
 
-.forbidden-lands .stronghold .gears .name {
-	align-items: center;
-	flex-basis: 60%;
-	display: flex;
-}
+	.name {
+		align-items: center;
+		flex-basis: 60%;
+		display: flex;
+	}
 
-.forbidden-lands .stronghold .gears .header .name,
-.forbidden-lands .stronghold .gears .name .name,
-.forbidden-lands .stronghold .gears .bonus,
-.forbidden-lands .stronghold .gears .weight,
-.forbidden-lands .stronghold .gears .button {
-	margin-left: 4px;
-}
+	.header .name,
+	.name .name,
+	.bonus,
+	.quantity,
+	.weight,
+	.button {
+		margin-left: 4px;
+	}
 
-.forbidden-lands .stronghold .gears .bonus {
-	flex-basis: 15%;
-	text-align: center;
-}
+	.bonus,
+	.weight,
+	.quantity {
+		flex-basis: 15%;
+		text-align: center;
+	}
 
-.forbidden-lands .stronghold .gears .bonus.broken {
-	color: #a00;
-}
+	.bonus.broken {
+		color: #a00;
+	}
 
-.forbidden-lands .stronghold .gears .weight {
-	flex-basis: 15%;
-	text-align: center;
-}
-
-.forbidden-lands .stronghold .gears .button {
-	flex-basis: 10%;
-	font-size: 10px;
-	text-align: right;
+	.button {
+		flex-basis: 10%;
+		font-size: 10px;
+		text-align: right;
+	}
 }

--- a/src/styles/sheets/tab/_stronghold-gear.scss
+++ b/src/styles/sheets/tab/_stronghold-gear.scss
@@ -16,7 +16,7 @@
 
 	.name {
 		align-items: center;
-		flex-basis: 60%;
+		flex-basis: 42%;
 		display: flex;
 	}
 
@@ -34,6 +34,11 @@
 	.quantity {
 		flex-basis: 15%;
 		text-align: center;
+	}
+	input.quantity {
+		flex-basis: 8%;
+		margin-right: 3%;
+		margin-left: 5%;
 	}
 
 	.bonus.broken {

--- a/src/templates/raw-material.hbs
+++ b/src/templates/raw-material.hbs
@@ -6,13 +6,19 @@
 		<div class="header-stats">
 			<label>{{localize "GEAR.NAME"}}</label>
 			<input name="name" type="text" value="{{item.name}}" />
-			<label>{{localize "GEAR.COST"}}</label>
-			<input name="data.cost" type="text" value="{{data.cost}}" />
-			<label>{{localize "RAW_MATERIAL.SHELF_LIFE"}}</label>
-			<input name="data.shelfLife" type="text" value="{{data.shelfLife}}" />
+			<label>{{localize "ITEM.QUANTITY"}}</label>
+			<input name="data.quantity" type="text" value="{{data.quantity}}" />
 		</div>
 	</div>
 	<div class="item">
+		<div class="cost">
+			<label>{{localize "GEAR.COST"}}</label>
+			<input name="data.cost" type="text" value="{{data.cost}}" />
+		</div>
+		<div class="shelf-life">
+			<label>{{localize "RAW_MATERIAL.SHELF_LIFE"}}</label>
+			<input name="data.shelfLife" type="text" value="{{data.shelfLife}}" />
+		</div>
 		<div class="raw-materials">
 			<label>{{localize "BUILDING.RAW_MATERIALS"}}</label>
 			<input name="data.rawMaterials" type="text" value="{{data.rawMaterials}}" />

--- a/src/templates/tab/gear-character.hbs
+++ b/src/templates/tab/gear-character.hbs
@@ -113,7 +113,7 @@
                 </div>
                 <div class="header flex row">
                     <b class="name">{{localize "HEADER.RAW_MATERIAL"}}</b>
-                    <b class="bonus">{{localize "GEAR.BONUS"}}</b>
+                    <b class="bonus">{{localize "ITEM.QUANTITY"}}</b>
                     <b class="weight">{{localize "GEAR.WEIGHT"}}</b>
                     <a class="button item-create" title="Add Raw Material" data-type="rawMaterial"><i
                             class="fas fa-plus"></i></a>
@@ -128,9 +128,7 @@
                             </div>
                             <div class="name">{{item.name}}</div>
                         </div>
-                        <div class="bonus {{isBroken item}}">
-                            {{item.data.bonus.value}}
-                        </div>
+						<input class="quantity" type="number" data-dtype="Number" value="{{item.data.quantity}}" />
                         <div class="weight">{{itemWeight item.data.weight}}</div>
                         <div class="button">
                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>

--- a/src/templates/tab/gear-monster.hbs
+++ b/src/templates/tab/gear-monster.hbs
@@ -1,139 +1,131 @@
 <div class="flex column full">
-    <div class="gears item-list border grow">
-        <h1>{{localize "HEADER.GEAR"}}</h1>
-        {{#if (isMonsterTypeMount data.type)}}
-            <div class="flex row justify-end">
-                <div class="encumbrance-div flex">
-                    <a class="change-mounted" data-attribute="{{data.isMounted}}" title="{{localize 'GEAR.MOUNTED'}}">
-                        <i class="fas fa-horse"></i>
-                        <i class="far {{#if data.isMounted}}fa-check-circle{{else}}fa-circle{{/if}}"></i>
-                    </a>
-                    <div class="encumbrance{{#if data.encumbrance.over}} overencumbered{{/if}}"
-                        title="{{localize 'ENCUMBRANCE'}}">
-                        <i class="fas fa-weight-hanging"></i> {{data.encumbrance.value}} / {{data.encumbrance.max}}
-                    </div>
-                </div>
-            </div>
-        {{/if}}
-        <div class="items">
-            <div class="header flex row">
-                <b class="name">{{localize "HEADER.ARMOR"}}</b>
-                <b class="bonus">{{localize "ARMOR.RATING"}}</b>
-                <b class="weight">{{localize "GEAR.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Armor" data-type="armor"><i class="fas fa-plus"></i></a>
-            </div>
-            <div>
-                {{#each actor.items as |item|}}
-                    {{#if item.isArmor}}
-                        <div class="gear item flex row" data-item-id="{{item._id}}">
-                            <div class="name">
-                                <div class="image-container">
-                                    <div class="image" style="background-image: url('{{item.img}}')"></div>
-                                </div>
-                                <div class="name">{{item.name}}</div>
-                            </div>
-                            <div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
-                                {{item.data.bonus.value}}
-                            </div>
-                            <div class="weight">{{itemWeight item.data.weight}}</div>
-                            <div class="button">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-                            </div>
-                        </div>
-                    {{/if}}
-                {{/each}}
-            </div>
-            <div class="header flex row">
-                <b class="name">{{localize "HEADER.WEAPON"}}</b>
-                <b class="bonus">{{localize "WEAPON.BONUS"}}</b>
-                <b class="weight">{{localize "GEAR.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Weapon" data-type="weapon"><i class="fas fa-plus"></i></a>
-            </div>
-            <div>
-                {{#each actor.items as |item|}}
-                    {{#if item.isWeapon}}
-                        <div class="gear item flex row" data-item-id="{{item._id}}">
-                            <div class="name">
-                                <div class="image-container">
-                                    <div class="image" style="background-image: url('{{item.img}}')"></div>
-                                </div>
-                                <div class="name">{{item.name}}</div>
-                            </div>
-                            <div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
-                                {{item.data.bonus.value}}
-                                {{#if item.data.artifactBonus}}+ {{item.data.artifactBonus}}{{/if}}
-                            </div>
-                            <div class="weight">{{itemWeight item.data.weight}}</div>
-                            <div class="button">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-                            </div>
-                        </div>
-                    {{/if}}
-                {{/each}}
-            </div>
-            <div class="header flex row">
-                <b class="name">{{localize "HEADER.GEAR"}}</b>
-                <b class="bonus">{{localize "GEAR.BONUS"}}</b>
-                <b class="weight">{{localize "GEAR.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Gear" data-type="gear"><i class="fas fa-plus"></i></a>
-            </div>
-            <div>
-                {{#each actor.items as |item|}}
-                    {{#if item.isGear}}
-                        <div class="gear item flex row" data-item-id="{{item._id}}">
-                            <div class="name">
-                                <div class="image-container">
-                                    <div class="image" style="background-image: url('{{item.img}}')"></div>
-                                </div>
-                                <div class="name">{{item.name}}</div>
-                            </div>
-                            <div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
-                                {{item.data.bonus.value}}
-                            </div>
-                            <div class="weight">{{itemWeight item.data.weight}}</div>
-                            <div class="button">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-                            </div>
-                        </div>
-                    {{/if}}
-                {{/each}}
-            </div>
-            <div class="header flex row">
-                <b class="name">{{localize "HEADER.RAW_MATERIAL"}}</b>
-                <b class="bonus">{{localize "GEAR.BONUS"}}</b>
-                <b class="weight">{{localize "GEAR.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Raw Material" data-type="rawMaterial"><i
-                        class="fas fa-plus"></i></a>
-            </div>
-            <div>
-                {{#each actor.items as |item|}}
-                    {{#if item.isRawMaterial}}
-                        <div class="gear item flex row" data-item-id="{{item._id}}">
-                            <div class="name">
-                                <div class="image-container">
-                                    <div class="image" style="background-image: url('{{item.img}}')"></div>
-                                </div>
-                                <div class="name">{{item.name}}</div>
-                            </div>
-                            <div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
-                                {{item.data.bonus.value}}
-                            </div>
-                            <div class="weight">{{itemWeight item.data.weight}}</div>
-                            <div class="button">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-                            </div>
-                        </div>
-                    {{/if}}
-                {{/each}}
-            </div>
-        </div>
-    </div>
+	<div class="gears item-list border grow">
+		<h1>{{localize "HEADER.GEAR"}}</h1>
+		{{#if (isMonsterTypeMount data.type)}}
+		<div class="flex row justify-end">
+			<div class="encumbrance-div flex">
+				<a class="change-mounted" data-attribute="{{data.isMounted}}" title="{{localize 'GEAR.MOUNTED'}}">
+					<i class="fas fa-horse"></i>
+					<i class="far {{#if data.isMounted}}fa-check-circle{{else}}fa-circle{{/if}}"></i>
+				</a>
+				<div
+					class="encumbrance{{#if data.encumbrance.over}} overencumbered{{/if}}"
+					title="{{localize 'ENCUMBRANCE'}}"
+				>
+					<i class="fas fa-weight-hanging"></i> {{data.encumbrance.value}} / {{data.encumbrance.max}}
+				</div>
+			</div>
+		</div>
+		{{/if}}
+		<div class="items">
+			<div class="header flex row">
+				<b class="name">{{localize "HEADER.ARMOR"}}</b>
+				<b class="bonus">{{localize "ARMOR.RATING"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<a class="button item-create" title="Add Armor" data-type="armor"><i class="fas fa-plus"></i></a>
+			</div>
+			<div>
+				{{#each actor.items as |item|}} {{#if item.isArmor}}
+				<div class="gear item flex row" data-item-id="{{item._id}}">
+					<div class="name">
+						<div class="image-container">
+							<div class="image" style="background-image: url('{{item.img}}')"></div>
+						</div>
+						<div class="name">{{item.name}}</div>
+					</div>
+					<div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
+						{{item.data.bonus.value}}
+					</div>
+					<div class="weight">{{itemWeight item.data.weight}}</div>
+					<div class="button">
+						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
+						<a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+					</div>
+				</div>
+				{{/if}} {{/each}}
+			</div>
+			<div class="header flex row">
+				<b class="name">{{localize "HEADER.WEAPON"}}</b>
+				<b class="bonus">{{localize "WEAPON.BONUS"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<a class="button item-create" title="Add Weapon" data-type="weapon"><i class="fas fa-plus"></i></a>
+			</div>
+			<div>
+				{{#each actor.items as |item|}} {{#if item.isWeapon}}
+				<div class="gear item flex row" data-item-id="{{item._id}}">
+					<div class="name">
+						<div class="image-container">
+							<div class="image" style="background-image: url('{{item.img}}')"></div>
+						</div>
+						<div class="name">{{item.name}}</div>
+					</div>
+					<div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
+						{{item.data.bonus.value}} {{#if item.data.artifactBonus}}+ {{item.data.artifactBonus}}{{/if}}
+					</div>
+					<div class="weight">{{itemWeight item.data.weight}}</div>
+					<div class="button">
+						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
+						<a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+					</div>
+				</div>
+				{{/if}} {{/each}}
+			</div>
+			<div class="header flex row">
+				<b class="name">{{localize "HEADER.GEAR"}}</b>
+				<b class="bonus">{{localize "GEAR.BONUS"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<a class="button item-create" title="Add Gear" data-type="gear"><i class="fas fa-plus"></i></a>
+			</div>
+			<div>
+				{{#each actor.items as |item|}} {{#if item.isGear}}
+				<div class="gear item flex row" data-item-id="{{item._id}}">
+					<div class="name">
+						<div class="image-container">
+							<div class="image" style="background-image: url('{{item.img}}')"></div>
+						</div>
+						<div class="name">{{item.name}}</div>
+					</div>
+					<div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
+						{{item.data.bonus.value}}
+					</div>
+					<div class="weight">{{itemWeight item.data.weight}}</div>
+					<div class="button">
+						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
+						<a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+					</div>
+				</div>
+				{{/if}} {{/each}}
+			</div>
+			<div class="header flex row">
+				<b class="name">{{localize "HEADER.RAW_MATERIAL"}}</b>
+				<b class="bonus">{{localize "ITEM.QUANTITY"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<a class="button item-create" title="Add Raw Material" data-type="rawMaterial"
+					><i class="fas fa-plus"></i
+				></a>
+			</div>
+			<div>
+				{{#each actor.items as |item|}} {{#if item.isRawMaterial}}
+				<div class="gear item flex row" data-item-id="{{item._id}}">
+					<div class="name">
+						<div class="image-container">
+							<div class="image" style="background-image: url('{{item.img}}')"></div>
+						</div>
+						<div class="name">{{item.name}}</div>
+					</div>
+					<input class="quantity" type="number" data-dtype="Number" value="{{item.data.quantity}}" />
+					<div class="weight">{{itemWeight item.data.weight}}</div>
+					<div class="button">
+						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
+						<a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+					</div>
+				</div>
+				{{/if}} {{/each}}
+			</div>
+		</div>
+	</div>
 </div>

--- a/src/templates/tab/gear-stronghold.hbs
+++ b/src/templates/tab/gear-stronghold.hbs
@@ -6,7 +6,7 @@
 				<b class="name">{{localize "HEADER.ARMOR"}}</b>
 				<b class="bonus">{{localize "ARMOR.RATING"}}</b>
 				<b class="quantity">{{localize "ITEM.QUANTITY"}}</b>
-				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}} / {{localize "ARMOR.TOTAL"}}</b>
 				<a class="button item-create" title="Add Armor" data-type="armor"><i class="fas fa-plus"></i></a>
 			</div>
 			<div>
@@ -21,8 +21,8 @@
 					<div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
 						{{item.data.bonus.value}}
 					</div>
-					<div class="quantity">{{item.data.quantity}}</div>
-					<div class="weight">{{itemWeight item.data.weight}}</div>
+					<input class="quantity" type="number" data-dtype="Number" value="{{item.data.quantity}}" />
+					<div class="weight">{{itemWeight item.data.weight}} / {{item.totalWeight}}</div>
 					<div class="button">
 						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
 						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
@@ -35,7 +35,7 @@
 				<b class="name">{{localize "HEADER.WEAPON"}}</b>
 				<b class="bonus">{{localize "WEAPON.BONUS"}}</b>
 				<b class="quantity">{{localize "ITEM.QUANTITY"}}</b>
-				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}} / {{localize "ARMOR.TOTAL"}}</b>
 				<a class="button item-create" title="Add Weapon" data-type="weapon"><i class="fas fa-plus"></i></a>
 			</div>
 			<div>
@@ -50,8 +50,8 @@
 					<div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
 						{{item.data.bonus.value}} {{#if item.data.artifactBonus}}+ {{item.data.artifactBonus}}{{/if}}
 					</div>
-					<div class="quantity">{{item.data.quantity}}</div>
-					<div class="weight">{{itemWeight item.data.weight}}</div>
+					<input class="quantity" type="number" data-dtype="Number" value="{{item.data.quantity}}" />
+					<div class="weight">{{itemWeight item.data.weight}} / {{item.totalWeight}}</div>
 					<div class="button">
 						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
 						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
@@ -64,7 +64,7 @@
 				<b class="name">{{localize "HEADER.GEAR"}}</b>
 				<b class="bonus">{{localize "GEAR.BONUS"}}</b>
 				<b class="quantity">{{localize "ITEM.QUANTITY"}}</b>
-				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}} / {{localize "ARMOR.TOTAL"}}</b>
 				<a class="button item-create" title="Add Gear" data-type="gear"><i class="fas fa-plus"></i></a>
 			</div>
 			<div>
@@ -79,8 +79,8 @@
 					<div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
 						{{item.data.bonus.value}}
 					</div>
-					<div class="quantity">{{item.data.quantity}}</div>
-					<div class="weight">{{itemWeight item.data.weight}}</div>
+					<input class="quantity" type="number" data-dtype="Number" value="{{item.data.quantity}}" />
+					<div class="weight">{{itemWeight item.data.weight}} / {{item.totalWeight}}</div>
 					<div class="button">
 						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
 						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
@@ -93,7 +93,7 @@
 				<b class="name">{{localize "HEADER.RAW_MATERIAL"}}</b>
 				<b class="bonus">&nbsp;</b>
 				<b class="quantity">{{localize "ITEM.QUANTITY"}}</b>
-				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}} / {{localize "ARMOR.TOTAL"}}</b>
 				<a class="button item-create" title="Add Raw Material" data-type="rawMaterial"
 					><i class="fas fa-plus"></i
 				></a>
@@ -108,7 +108,7 @@
 						<div class="name">{{item.name}}</div>
 					</div>
 					<div class="bonus">&nbsp;</div>
-					<div class="quantity">{{item.data.quantity}}</div>
+					<input class="quantity" type="number" data-dtype="Number" value="{{item.data.quantity}}" />
 					<div class="weight">{{itemWeight item.data.weight}} / {{item.totalWeight}}</div>
 					<div class="button">
 						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>

--- a/src/templates/tab/gear-stronghold.hbs
+++ b/src/templates/tab/gear-stronghold.hbs
@@ -1,125 +1,123 @@
 <div class="flex column full">
-    <div class="gears item-list border grow">
-        <h1>{{localize "HEADER.GEAR"}}</h1>
-        <div class="items">
-            <div class="header flex row">
-                <b class="name">{{localize "HEADER.ARMOR"}}</b>
-                <b class="bonus">{{localize "ARMOR.RATING"}}</b>
-                <b class="weight">{{localize "GEAR.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Armor" data-type="armor"><i class="fas fa-plus"></i></a>
-            </div>
-            <div>
-                {{#each actor.items as |item|}}
-                {{#if item.isArmor}}
-                <div class="gear item flex row" data-item-id="{{item._id}}">
-                    <div class="name">
-                        <div class="image-container">
-                            <div class="image" style="background-image: url('{{item.img}}')"></div>
-                        </div>
-                        <div class="name">{{item.name}}</div>
-                    </div>
-                    <div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
-                        {{item.data.bonus.value}}
-                    </div>
-                    <div class="weight">{{itemWeight item.data.weight}}</div>
-                    <div class="button">
-                        <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                        <a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
-                        <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-                    </div>
-                </div>
-                {{/if}}
-                {{/each}}
-            </div>
-            <div class="header flex row">
-                <b class="name">{{localize "HEADER.WEAPON"}}</b>
-                <b class="bonus">{{localize "WEAPON.BONUS"}}</b>
-                <b class="weight">{{localize "GEAR.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Weapon" data-type="weapon"><i class="fas fa-plus"></i></a>
-            </div>
-            <div>
-                {{#each actor.items as |item|}}
-                {{#if item.isWeapon}}
-                <div class="gear item flex row" data-item-id="{{item._id}}">
-                    <div class="name">
-                        <div class="image-container">
-                            <div class="image" style="background-image: url('{{item.img}}')"></div>
-                        </div>
-                        <div class="name">{{item.name}}</div>
-                    </div>
-                    <div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
-                        {{item.data.bonus.value}}
-                        {{#if item.data.artifactBonus}}+ {{item.data.artifactBonus}}{{/if}}
-                    </div>
-                    <div class="weight">{{itemWeight item.data.weight}}</div>
-                    <div class="button">
-                        <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                        <a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
-                        <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-                    </div>
-                </div>
-                {{/if}}
-                {{/each}}
-            </div>
-            <div class="header flex row">
-                <b class="name">{{localize "HEADER.GEAR"}}</b>
-                <b class="bonus">{{localize "GEAR.BONUS"}}</b>
-                <b class="weight">{{localize "GEAR.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Gear" data-type="gear"><i class="fas fa-plus"></i></a>
-            </div>
-            <div>
-                {{#each actor.items as |item|}}
-                {{#if item.isGear}}
-                <div class="gear item flex row" data-item-id="{{item._id}}">
-                    <div class="name">
-                        <div class="image-container">
-                            <div class="image" style="background-image: url('{{item.img}}')"></div>
-                        </div>
-                        <div class="name">{{item.name}}</div>
-                    </div>
-                    <div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
-                        {{item.data.bonus.value}}
-                    </div>
-                    <div class="weight">{{itemWeight item.data.weight}}</div>
-                    <div class="button">
-                        <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                        <a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
-                        <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-                    </div>
-                </div>
-                {{/if}}
-                {{/each}}
-            </div>
-            <div class="header flex row">
-                <b class="name">{{localize "HEADER.RAW_MATERIAL"}}</b>
-                <b class="bonus">{{localize "GEAR.BONUS"}}</b>
-                <b class="weight">{{localize "GEAR.WEIGHT"}}</b>
-                <a class="button item-create" title="Add Raw Material" data-type="rawMaterial"><i
-                        class="fas fa-plus"></i></a>
-            </div>
-            <div>
-                {{#each actor.items as |item|}}
-                {{#if item.isRawMaterial}}
-                <div class="gear item flex row" data-item-id="{{item._id}}">
-                    <div class="name">
-                        <div class="image-container">
-                            <div class="image" style="background-image: url('{{item.img}}')"></div>
-                        </div>
-                        <div class="name">{{item.name}}</div>
-                    </div>
-                    <div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
-                        {{item.data.bonus.value}}
-                    </div>
-                    <div class="weight">{{itemWeight item.data.weight}}</div>
-                    <div class="button">
-                        <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                        <a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
-                        <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-                    </div>
-                </div>
-                {{/if}}
-                {{/each}}
-            </div>
-        </div>
-    </div>
+	<div class="gears item-list border grow">
+		<h1>{{localize "HEADER.GEAR"}}</h1>
+		<div class="items">
+			<div class="header flex row">
+				<b class="name">{{localize "HEADER.ARMOR"}}</b>
+				<b class="bonus">{{localize "ARMOR.RATING"}}</b>
+				<b class="quantity">{{localize "ITEM.QUANTITY"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<a class="button item-create" title="Add Armor" data-type="armor"><i class="fas fa-plus"></i></a>
+			</div>
+			<div>
+				{{#each actor.items as |item|}} {{#if item.isArmor}}
+				<div class="gear item flex row" data-item-id="{{item._id}}">
+					<div class="name">
+						<div class="image-container">
+							<div class="image" style="background-image: url('{{item.img}}')"></div>
+						</div>
+						<div class="name">{{item.name}}</div>
+					</div>
+					<div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
+						{{item.data.bonus.value}}
+					</div>
+					<div class="quantity">{{item.data.quantity}}</div>
+					<div class="weight">{{itemWeight item.data.weight}}</div>
+					<div class="button">
+						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
+						<a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+					</div>
+				</div>
+				{{/if}} {{/each}}
+			</div>
+			<div class="header flex row">
+				<b class="name">{{localize "HEADER.WEAPON"}}</b>
+				<b class="bonus">{{localize "WEAPON.BONUS"}}</b>
+				<b class="quantity">{{localize "ITEM.QUANTITY"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<a class="button item-create" title="Add Weapon" data-type="weapon"><i class="fas fa-plus"></i></a>
+			</div>
+			<div>
+				{{#each actor.items as |item|}} {{#if item.isWeapon}}
+				<div class="gear item flex row" data-item-id="{{item._id}}">
+					<div class="name">
+						<div class="image-container">
+							<div class="image" style="background-image: url('{{item.img}}')"></div>
+						</div>
+						<div class="name">{{item.name}}</div>
+					</div>
+					<div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
+						{{item.data.bonus.value}} {{#if item.data.artifactBonus}}+ {{item.data.artifactBonus}}{{/if}}
+					</div>
+					<div class="quantity">{{item.data.quantity}}</div>
+					<div class="weight">{{itemWeight item.data.weight}}</div>
+					<div class="button">
+						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
+						<a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+					</div>
+				</div>
+				{{/if}} {{/each}}
+			</div>
+			<div class="header flex row">
+				<b class="name">{{localize "HEADER.GEAR"}}</b>
+				<b class="bonus">{{localize "GEAR.BONUS"}}</b>
+				<b class="quantity">{{localize "ITEM.QUANTITY"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<a class="button item-create" title="Add Gear" data-type="gear"><i class="fas fa-plus"></i></a>
+			</div>
+			<div>
+				{{#each actor.items as |item|}} {{#if item.isGear}}
+				<div class="gear item flex row" data-item-id="{{item._id}}">
+					<div class="name">
+						<div class="image-container">
+							<div class="image" style="background-image: url('{{item.img}}')"></div>
+						</div>
+						<div class="name">{{item.name}}</div>
+					</div>
+					<div class="bonus {{#unless item.data.bonus.value }}broken{{/unless}}">
+						{{item.data.bonus.value}}
+					</div>
+					<div class="quantity">{{item.data.quantity}}</div>
+					<div class="weight">{{itemWeight item.data.weight}}</div>
+					<div class="button">
+						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
+						<a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+					</div>
+				</div>
+				{{/if}} {{/each}}
+			</div>
+			<div class="header flex row">
+				<b class="name">{{localize "HEADER.RAW_MATERIAL"}}</b>
+				<b class="bonus">&nbsp;</b>
+				<b class="quantity">{{localize "ITEM.QUANTITY"}}</b>
+				<b class="weight">{{localize "GEAR.WEIGHT"}}</b>
+				<a class="button item-create" title="Add Raw Material" data-type="rawMaterial"
+					><i class="fas fa-plus"></i
+				></a>
+			</div>
+			<div>
+				{{#each actor.items as |item|}} {{#if item.isRawMaterial}}
+				<div class="gear item flex row" data-item-id="{{item._id}}">
+					<div class="name">
+						<div class="image-container">
+							<div class="image" style="background-image: url('{{item.img}}')"></div>
+						</div>
+						<div class="name">{{item.name}}</div>
+					</div>
+					<div class="bonus">&nbsp;</div>
+					<div class="quantity">{{item.data.quantity}}</div>
+					<div class="weight">{{itemWeight item.data.weight}} / {{item.totalWeight}}</div>
+					<div class="button">
+						<a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+						<a class="item-control item-post" title="Post Item"><i class="fas fa-comment"></i></a>
+						<a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+					</div>
+				</div>
+				{{/if}} {{/each}}
+			</div>
+		</div>
+	</div>
 </div>

--- a/src/templates/tab/gear/gear-supply.hbs
+++ b/src/templates/tab/gear/gear-supply.hbs
@@ -1,28 +1,25 @@
 {{#if (or showCostField showSupplyField)}}
 <div class="supply border">
-    {{#if showCostField}}
-    <label>{{localize "GEAR.COST"}}</label>
-    <input name="data.cost" type="text" value="{{data.cost}}" />
-    {{/if}}
-    {{#if showSupplyField}}
-    <label>{{localize "GEAR.SUPPLY"}}</label>
-    <input name="data.supply" type="text" value="{{data.supply}}" />
-    {{/if}}
+	{{#if showCostField}}
+	<label>{{localize "GEAR.COST"}}</label>
+	<input name="data.cost" type="text" value="{{data.cost}}" />
+	{{/if}} {{#if showSupplyField}}
+	<label>{{localize "GEAR.SUPPLY"}}</label>
+	<input name="data.supply" type="text" value="{{data.supply}}" />
+	{{/if}}
 </div>
-{{/if}}
-
-{{#if showCraftingFields}}
+{{/if}} {{#if showCraftingFields}}
 <div class="crafting border">
-    <label>{{localize "GEAR.RAW_MATERIAL"}}</label>
-    <input name="data.rawMaterials" type="text" value="{{data.rawMaterials}}" />
+	<label>{{localize "GEAR.RAW_MATERIAL"}}</label>
+	<input name="data.rawMaterials" type="text" value="{{data.rawMaterials}}" />
 
-    <label>{{localize "GEAR.TIME"}}</label>
-    <input name="data.time" type="text" value="{{data.time}}" />
+	<label>{{localize "GEAR.TIME"}}</label>
+	<input name="data.time" type="text" value="{{data.time}}" />
 
-    <label>{{localize "GEAR.TALENT"}}</label>
-    <input name="data.talent" type="text" value="{{data.talent}}" />
+	<label>{{localize "GEAR.TALENT"}}</label>
+	<input name="data.talent" type="text" value="{{data.talent}}" />
 
-    <label>{{localize "GEAR.TOOLS"}}</label>
-    <input name="data.tools" type="text" value="{{data.tools}}" />
+	<label>{{localize "GEAR.TOOLS"}}</label>
+	<input name="data.tools" type="text" value="{{data.tools}}" />
 </div>
 {{/if}}

--- a/static/template.json
+++ b/static/template.json
@@ -298,6 +298,9 @@
 				"talent": "",
 				"tools": ""
 			},
+			"trade": {
+				"quantity": 1
+			},
 			"rollModifiers": {
 				"rollModifiers": {}
 			},
@@ -310,7 +313,7 @@
 			}
 		},
 		"weapon": {
-			"templates": ["bonus", "craftable", "rollModifiers", "artifact"],
+			"templates": ["bonus", "craftable", "rollModifiers", "artifact", "trade"],
 			"category": "melee",
 			"skillBonus": "",
 			"damage": 1,
@@ -330,7 +333,7 @@
 			"weight": "regular"
 		},
 		"armor": {
-			"templates": ["bonus", "craftable", "rollModifiers", "artifact"],
+			"templates": ["bonus", "craftable", "rollModifiers", "artifact", "trade"],
 			"cost": 0,
 			"part": "body",
 			"features": "",
@@ -359,13 +362,13 @@
 			"healingTime": ""
 		},
 		"gear": {
-			"templates": ["bonus", "craftable", "rollModifiers", "artifact"],
+			"templates": ["bonus", "craftable", "rollModifiers", "artifact", "trade"],
 			"cost": "",
 			"supply": "",
 			"weight": "regular"
 		},
 		"rawMaterial": {
-			"templates": ["bonus", "craftable"],
+			"templates": ["bonus", "craftable", "trade"],
 			"cost": "",
 			"shelfLife": ""
 		},


### PR DESCRIPTION
Thanks to @Darkwuulf over on the Year Zero Worlds discord for pointing out this issue. This feature closes #75 🎉 

This feature mainly introduces editing item quantities from Stronghold sheets.

![example](https://user-images.githubusercontent.com/9851733/114757755-83e05000-9d5c-11eb-9b30-2aa92e5a6189.png)

Raw Materials can also have quantity edited directly in the sheet or also in the gear section of the Character and Monster sheets.