### PR TITLE
Change Pride button to 'button' type

### DIFF
--- a/src/templates/tab/bio.hbs
+++ b/src/templates/tab/bio.hbs
@@ -1,7 +1,7 @@
 <div class="bio-tab border">
 	<div class="section">
 		<h1>
-			<button id="pride-roll-btn">
+			<button type="button" id="pride-roll-btn">
 				<i class="fas fa-dice"></i>{{localize "HEADER.PRIDE"}}
 			</button>
 		</h1>


### PR DESCRIPTION
Focusing an element on the sheet and pressing 'enter' causes Pride to be rolled because buttons are type "submit" by default. 