### PR TITLE
🐛 Damage, Critical Injuries, Encumbrance and Artifacts

### DIFF
--- a/src/module/sheets/actor/character.js
+++ b/src/module/sheets/actor/character.js
@@ -116,9 +116,10 @@ export class ForbiddenLandsCharacterSheet extends ForbiddenLandsActorSheet {
 			parseInt(data.data.currency.silver.value) +
 			parseInt(data.data.currency.copper.value);
 		weightCarried += Math.floor(coinsCarried / 100) * 0.5;
-		/* Needs Fix */
-		//let modifiers = this.getRollModifiers("CARRYING_CAPACITY", null);
-		const weightAllowed = data.data.attribute.strength.max * 2; /* + modifiers.modifier; */
+		const modifiers = this.actor.getRollModifierOptions("carryingCapacity");
+		const weightAllowed = modifiers
+			? data.data.attribute.strength.max * 2 + parseInt(modifiers[0].value) || 0
+			: data.data.attribute.strength.max * 2;
 		data.data.encumbrance = {
 			value: weightCarried,
 			max: weightAllowed,

--- a/src/module/system/config.js
+++ b/src/module/system/config.js
@@ -116,6 +116,7 @@ FBL.i18n = {
 	"travel-kill-prey": "FLPS.TRAVEL_ROLL.KILL_PREY",
 	"travel-catch-fish": "FLPS.TRAVEL_ROLL.CATCH_FISH",
 	"travel-make-camp": "FLPS.TRAVEL_ROLL.MAKE_CAMP",
+	carryingCapacity: "CARRYING_CAPACITY",
 };
 
 FBL.itemTypes = [

--- a/src/templates/chat/item.hbs
+++ b/src/templates/chat/item.hbs
@@ -134,7 +134,9 @@
 					<strong>
 						{{localize "CRITICAL_INJURY.LIMIT"}}:
 					</strong>
-					{{data.limit}}
+					<span data-type="limit">
+						{{data.limit}}
+					</span>
 				</p>
 			{{/if}}
 			{{#if data.healingTime}}

--- a/src/templates/dice/dialog.hbs
+++ b/src/templates/dice/dialog.hbs
@@ -12,7 +12,7 @@
 					data-operator="plus" data-type="{{key}}"><i class="fas fa-plus-square"></i></a>
 			</div>
 			{{/each}}
-			<label for="Artifact">{{localize "DICE.ARTIFACTS"}}:</label><input type="text" id="artifact" name="artifact"
+			<label for="artifact">{{localize "DICE.ARTIFACTS"}}:</label><input type="text" id="artifact" name="artifact"
 				value="{{artifact}}" autocomplete="off" />
 		</div>
 		<div class="options">


### PR DESCRIPTION
- Reduce calculated attack damage by 1 so that it is in line with rules.
- Fix Critical injuries drag dropped to character sheets.
- Fix Carrying Capacity modifier not applying its modifier.
- Make roll dialog more robust when it comes to parsing artifacts.