### PR TITLE
fix: Party sheet - bug with null assigned actor

### DIFF
--- a/src/actor/party/party-sheet.js
+++ b/src/actor/party/party-sheet.js
@@ -34,7 +34,9 @@ export class ForbiddenLandsPartySheet extends ActorSheet {
 			if (typeof travelAction === "object") {
 				for (let i = 0; i < travelAction.length; i++) {
 					assignedActorId = travelAction[i];
-					data.travel[travelActionKey][assignedActorId] = game.actors.get(assignedActorId).data;
+					if (assignedActorId != null) {
+						data.travel[travelActionKey][assignedActorId] = game.actors.get(assignedActorId).data;
+					}
 				}
 			} else if (travelAction !== "") {
 				data.travel[travelActionKey][travelAction] = game.actors.get(travelAction).data;

--- a/src/actor/party/party-sheet.js
+++ b/src/actor/party/party-sheet.js
@@ -49,7 +49,8 @@ export class ForbiddenLandsPartySheet extends ActorSheet {
 		super.activateListeners(html);
 
 		html.find(".item-delete").click(this.handleRemoveMember.bind(this));
-		html.find(".reset").click(() => {
+		html.find(".reset").click((event) => {
+			event.preventDefault();
 			this.assignPartyMembersToAction(this.actor.data.data.members, "other");
 			this.render(true);
 		});
@@ -72,6 +73,7 @@ export class ForbiddenLandsPartySheet extends ActorSheet {
 	}
 
 	async handleRemoveMember(event) {
+		event.preventDefault();
 		const div = $(event.currentTarget).parents(".party-member");
 		const entityId = div.data("entity-id");
 


### PR DESCRIPTION
I have stressed a lot the party sheet and sometimes the `assignedActorId` can be `null` and causes the sheet to not display (rendering crash).

Adding this sole line that check if isn't null avoid this kind of problem.