### PR TITLE
Fix: :bug: Add gear data to monster attack rolls

### DIFF
--- a/src/actor/monster/monster-sheet.js
+++ b/src/actor/monster/monster-sheet.js
@@ -71,6 +71,12 @@ export class ForbiddenLandsMonsterSheet extends ForbiddenLandsActorSheet {
 		const options = {
 			name: attack.name,
 			maxPush: rollOptions.unlimitedPush ? 10000 : "0",
+			gear: {
+				name: attack.name,
+				label: attack.name,
+				type: "monsterAttack",
+				itemId: attack.id,
+			},
 			...rollOptions,
 		};
 		const roll = FBLRoll.create(`${attack.data.data.dice}db[${attack.name}]`, {}, options);


### PR DESCRIPTION
Fixes #229 

> **Note** This resolves an issue of uniformity in the FBL roll API