### PR TITLE
fix: use correct attributes when conditions block resting.

### DIFF
--- a/src/actor/actor-document.js
+++ b/src/actor/actor-document.js
@@ -143,7 +143,7 @@ export class ForbiddenLandsActor extends Actor {
 		const data = {
 			attribute: {
 				agility: {
-					value: isBlocked("thirsty") ? this.attributes.strength.value : this.attributes.agility.max,
+					value: isBlocked("thirsty") ? this.attributes.agility.value : this.attributes.agility.max,
 				},
 				strength: {
 					value: isBlocked("thirsty", "cold", "hungry")
@@ -152,7 +152,7 @@ export class ForbiddenLandsActor extends Actor {
 				},
 				wits: {
 					value: isBlocked("thirsty", "cold", "sleepy")
-						? this.attributes.strength.value
+						? this.attributes.wits.value
 						: this.attributes.wits.max,
 				},
 				empathy: {


### PR DESCRIPTION
Strength was being used instead of wits and agility when resting while under a condition (thirsty for **agility**, thirsty cold sleepy for **wits**).