### PR TITLE
fix: 🐛 xp gain message formating

### DIFF
--- a/src/components/macros/experience-dialog.js
+++ b/src/components/macros/experience-dialog.js
@@ -91,7 +91,7 @@ export function experienceDialog() {
 				{
 					user: game.user.id,
 					speaker: ChatMessage.getSpeaker(),
-					content: game.i18n.localize("EXPERIENCE.CHAT.MESSAGE", {
+					content: game.i18n.format("EXPERIENCE.CHAT.MESSAGE", {
 						name: playerCharacter.name,
 						xpGains: xpGains,
 						newXp: newXp,


### PR DESCRIPTION
Fixed the chat message when gaining xp to correctly format it.