### PR TITLE
fix: 🐛 Negative successes not triggering mishaps

### DIFF
--- a/.changeset/two-eels-enjoy.md
+++ b/.changeset/two-eels-enjoy.md
@@ -1,0 +1,5 @@
+---
+"forbidden-lands": patch
+---
+
+Fixes an issue where negative successes in journey rolls would not trigger mishaps

--- a/src/components/roll-engine/engine.js
+++ b/src/components/roll-engine/engine.js
@@ -773,7 +773,7 @@ export class FBLRoll extends YearZeroRoll {
 		const mishap =
 			this.options.mishapType !== "spell" &&
 			this.options.mishapTable &&
-			this.successCount === 0;
+			this.successCount <= 0;
 		return spellMishap || mishap;
 	}
 

--- a/src/system/core/hooks.js
+++ b/src/system/core/hooks.js
@@ -258,13 +258,15 @@ export default function registerHooks() {
 	});
 
 	Hooks.on("changeSidebarTab", (app) => {
-		if (
-			app.tabName !== "journal" ||
-			!Object.keys(CONFIG.fbl.adventureSites.types).length
-		)
-			return;
+		const shouldRender =
+			app.tabName === "journal" &&
+			Object.keys(CONFIG.fbl.adventureSites.types).length &&
+			!app.element.find("#create-adventure-site").length;
+
+		if (!shouldRender) return;
+
 		const adventureSiteButton = $(
-			`<button><i class="fas fa-castle"></i> Create Adventure Site</button>`,
+			`<button id="create-adventure-site"><i class="fas fa-castle"></i> Create Adventure Site</button>`,
 		);
 		adventureSiteButton.on("click", () => {
 			adventureSiteCreateDialog();


### PR DESCRIPTION
Fixes #431
