### PR TITLE
✨Allow Mount actors to push their rolls

### DIFF
--- a/.changeset/lucky-buses-float.md
+++ b/.changeset/lucky-buses-float.md
@@ -1,0 +1,5 @@
+---
+"forbidden-lands": patch
+---
+
+Allow Mount-type actors to push their rolls

--- a/src/components/roll-engine/engine.js
+++ b/src/components/roll-engine/engine.js
@@ -471,7 +471,7 @@ export class FBLRollHandler extends FormApplication {
 		// eslint-disable-next-line no-nested-ternary
 		const maxPush = unlimitedPush
 			? 10000
-			: this.options.actorType === "monster"
+			: game.actors.get(this.options.actorId).system.type === "monster"
 				? "0"
 				: 1;
 		return {


### PR DESCRIPTION
According to PHB p.115:

> MOVE: When you are mounted, and are about to
perform an action that usually requires you to
roll MOVE (such as moving into a ROUGH zone),
roll for ANIMAL HANDLING instead, using the animal’s
Agility (not your Empathy).
Pushing such a roll will not give you Willpower Points.

This change allows for Mount actors to push their rolls:

![obraz](https://github.com/user-attachments/assets/551fa07e-b7e0-448d-b5a8-33be846da431)
![obraz](https://github.com/user-attachments/assets/ea73904f-ecb8-4409-ab09-37a2afff9a33)
