### PR TITLE
Fix for #410 - override of actor getRollData

### DIFF
--- a/.changeset/breezy-foxes-unite.md
+++ b/.changeset/breezy-foxes-unite.md
@@ -1,0 +1,5 @@
+---
+"forbidden-lands": patch
+---
+
+Fix for #410 - removed override of actor getRollData

--- a/src/actor/actor-document.js
+++ b/src/actor/actor-document.js
@@ -37,8 +37,7 @@ export class ForbiddenLandsActor extends Actor {
 		return this.getFlag("forbidden-lands", "unlimitedPush") ?? false;
 	}
 
-	/* Override */
-	getRollData() {
+	getRollContext() {
 		return {
 			alias: this.token?.name || this.name,
 			actorId: this.id,

--- a/src/actor/actor-sheet.js
+++ b/src/actor/actor-sheet.js
@@ -35,7 +35,7 @@ export class ForbiddenLandsActorSheet extends ActorSheet {
 	}
 
 	get rollData() {
-		return this.actor.getRollData();
+		return this.actor.getRollContext();
 	}
 
 	get config() {


### PR DESCRIPTION
The simple option here to fix #410 was to just rename the method and avoid overriding.

Fix is good in v12 and v13.