### PR TITLE
Fixes for #454 - armor sheet enrichment

### DIFF
--- a/.changeset/wet-chicken-hunt.md
+++ b/.changeset/wet-chicken-hunt.md
@@ -1,0 +1,5 @@
+---
+"forbidden-lands": patch
+---
+
+Fix for #454 - Features field now enriched for Armor-type items.

--- a/src/item/armor/armor-sheet.js
+++ b/src/item/armor/armor-sheet.js
@@ -14,4 +14,20 @@ export class ForbiddenLandsArmorSheet extends ForbiddenLandsItemSheet {
 			],
 		});
 	}
+
+	async getData(options = {}) {
+		const data = await super.getData(options);
+
+		data.system.enrichedFeatures =
+			await foundry.applications.ux.TextEditor.enrichHTML(
+				data.system.features ?? "",
+				{
+					async: true,
+					secrets: game.user.isGM,
+					relativeTo: this.item,
+				},
+			);
+
+		return data;
+	}
 }

--- a/templates/item/armor/main-tab.hbs
+++ b/templates/item/armor/main-tab.hbs
@@ -23,7 +23,13 @@
 	</div>
 	<div class="grid-full-line">
 		<label>{{localize "WEAPON.FEATURES.TITLE"}}</label>
-		{{editor system.features target="system.features" owner=owner button=true editable=true}}
+		{{#if editable}}
+			{{editor system.features target="system.features" owner=owner button=true editable=true}}
+		{{else}}
+			<div class="editor-content">
+				{{{system.enrichedFeatures}}}
+			</div>
+		{{/if}}
 	</div>
 </div>
 <div class="roll-modifiers border">


### PR DESCRIPTION
The cause of this is a difference in the schema between Armor and all the other item types. At this point unwinding the difference would be a huge pain, so I've hacked in a little fix that should solve the problem until we refactor the system more broadly. Fix is good in v12 and v13.