### PR TITLE
Issue-472 - PCs created unlinked (and hostile)

### DIFF
--- a/.changeset/empty-suns-play.md
+++ b/.changeset/empty-suns-play.md
@@ -1,0 +1,5 @@
+---
+"forbidden-lands": patch
+---
+
+Fix for #472. Characters created by non-GMs will now be linked and Friendly by default.

--- a/src/actor/actor-document.js
+++ b/src/actor/actor-document.js
@@ -117,6 +117,13 @@ export class ForbiddenLandsActor extends Actor {
 					break;
 			}
 		}
+
+		if (data.type === "character" && !game.user?.isGM) {
+			data.prototypeToken ??= {};
+			data.prototypeToken.actorLink = true;
+			data.prototypeToken.disposition = 1;
+		}
+
 		return super.create(data, options);
 	}
 


### PR DESCRIPTION
This is a tough one to solve correctly because the system doesn't currently differentiate between Player Characters (should be linked, should be Friendly by default) and non-Monster NPCs (should usually NOT be linked, should usually be Hostile by default.

I think until/unless a distinction is created, the best solve for this is to set a new Character as Linked and Friendly automatically if they are created by a user who is NOT the GM, and to keep the current behavior when the GM creates Characters. Tweak is good in v12 and v13.

Eventually, the correctly solution is to refactor the Actor types and set defaults appropriately.