### PR TITLE
Fixes for #471 and #455 - monster attack issues

### DIFF
--- a/.changeset/smart-penguins-march.md
+++ b/.changeset/smart-penguins-march.md
@@ -1,0 +1,5 @@
+---
+"forbidden-lands": patch
+---
+
+Fix for #471 and #455. Monster fear attacks now calculate correctly, and the chat card displays the correct values.

--- a/src/actor/monster/monster-sheet.js
+++ b/src/actor/monster/monster-sheet.js
@@ -80,6 +80,7 @@ export class ForbiddenLandsMonsterSheet extends ForbiddenLandsActorSheet {
 			isMonsterAttack: true,
 			damage: Number(attack.damage || 0),
 			gear,
+			attack: attack,
 			...rollOptions,
 		};
 		const dice = attack.itemProperties.usingStrength

--- a/src/components/roll-engine/engine.js
+++ b/src/components/roll-engine/engine.js
@@ -752,6 +752,13 @@ export class FBLRoll extends YearZeroRoll {
 	}
 
 	get damage() {
+		if (
+			this.options?.isMonsterAttack &&
+			this.options?.attack?.system?.damageType === "fear"
+		) {
+			return this.successCount;
+		}
+
 		const modifier = this.type === "spell" ? 0 : -1;
 		return (
 			(this.options.damage || 0) + Math.max(this.successCount + modifier, 0)

--- a/templates/components/item-chatcard.hbs
+++ b/templates/components/item-chatcard.hbs
@@ -199,16 +199,16 @@
 				</p>
 			{{/if}}
 			<strong>{{localize "MONSTER.DICE"}}</strong>:
-			{{data.dice}}
+			{{system.dice}}
 			<br />
 			<strong>{{localize "MONSTER.DAMAGE"}}</strong>:
-			{{data.damage}}
+			{{system.damage}}
 			<br />
 			<strong>{{localize "MONSTER.RANGE"}}</strong>:
-			{{data.range}}
+			{{weaponRange system.range}}
 			<br />
 			<strong>{{localize "MONSTER.DAMAGE_TYPE"}}</strong>:
-			{{data.damageType}}
+			{{damageType system.damageType}}
 		{{/if}}
 
 		{{#if isRawMaterial}}


### PR DESCRIPTION
Fixes both fear attack calculation and monster attack details showing correctly in the chat card. Good in v12 and v13.