### PR TITLE
🐛 Ensure current actor exists before checking for monster type

### DIFF
--- a/.changeset/little-boxes-fry.md
+++ b/.changeset/little-boxes-fry.md
@@ -1,0 +1,5 @@
+---
+"forbidden-lands": patch
+---
+
+Fix Generic Roll throw an error when there's no actor selected

--- a/src/components/roll-engine/engine.js
+++ b/src/components/roll-engine/engine.js
@@ -470,9 +470,7 @@ export class FBLRollHandler extends FormApplication {
 		// So we use a sufficiently large number instead.
 		// eslint-disable-next-line no-nested-ternary
 		const currentActor = game.actors.get(this.options.actorId);
-		const isMonster = currentActor
-			? currentActor.system.type === "monster"
-			: false;
+		const isMonster = currentActor?.system.type === "monster";
 		const maxPush = unlimitedPush ? 10000 : isMonster ? 0 : 1;
 		return {
 			name: this.title,

--- a/src/components/roll-engine/engine.js
+++ b/src/components/roll-engine/engine.js
@@ -469,11 +469,11 @@ export class FBLRollHandler extends FormApplication {
 		// however Infinity is finicky to serialize.
 		// So we use a sufficiently large number instead.
 		// eslint-disable-next-line no-nested-ternary
-		const maxPush = unlimitedPush
-			? 10000
-			: game.actors.get(this.options.actorId).system.type === "monster"
-				? "0"
-				: 1;
+		const currentActor = game.actors.get(this.options.actorId);
+		const isMonster = currentActor
+			? currentActor.system.type === "monster"
+			: false;
+		const maxPush = unlimitedPush ? 10000 : isMonster ? 0 : 1;
 		return {
 			name: this.title,
 			title: this.title,


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/fvtt-fria-ligan/forbidden-lands-foundry-vtt/pull/476