### PR TITLE
Fix extended semver strings parsing

### DIFF
--- a/src/utils/semver-compare.js
+++ b/src/utils/semver-compare.js
@@ -43,7 +43,7 @@ export default function semverComp(min, curr, max, opt = {}) {
 function coerceNum(string) {
 	if (typeof string !== "string")
 		throw new Error(`Wrong term passed ${string}`);
-	const array = Array.from(string.split("."), (v) => Number.parseInt(v));
+	const array = Array.from(string.split(".", 3), (v) => Number.parseInt(v));
 	if (array.some((v) => Number.isNaN(v)) || array.length !== 3)
 		throw new Error(`Invalid SemVer string: ${string}`);
 	array[0] = array[0] * 1000000;


### PR DESCRIPTION
According to https://semver.org, semver string has `MAJOR.MINOR.PATCH-PRERELEASE+BUILDMETADATA` format.

The current simple parsing approach will fail on extended semver strings that do not conform to the MAJOR.MINOR.PATCH triplet format.

Example:

```
forbidden-lands.js:281 Uncaught (in promise) Error: Invalid SemVer string: 13.0.0-next.0
    at coerceNum (forbidden-lands.js:281:79)
    at semverComp (forbidden-lands.js:267:29)
    at isCurrent (forbidden-lands.js:301:37)
    at handleDisplay (forbidden-lands.js:293:17)
    at displayMessages (forbidden-lands.js:288:39)
```

This change limits the split to the maximum of 3 terms, while keeping validation that expects a valid semver to contain at least these three.